### PR TITLE
Removing warnings.

### DIFF
--- a/solver_greedy_max.py
+++ b/solver_greedy_max.py
@@ -3,11 +3,11 @@
 The main executable.
 """
 
+from greedy_max_algorithm import *
 from astropy.table import Table
 from astropy.visualization import time_support
 time_support()
 
-from greedy_max_algorithm import *
 
 tabdir = './data/'
 


### PR DESCRIPTION
Python is complaining about `time_support()` before an `import` in `solver_greedy_max`.