### PR TITLE
Sched 30-29: Fix missing information in Resource and change naming convention to Visit

### DIFF
--- a/greedy_max/plan.py
+++ b/greedy_max/plan.py
@@ -99,7 +99,7 @@ class Plan:
             
         return orders
     
-    def get_unit_by_observation(self, site: Site, obs_idx: int ) -> Optional[SchedulingUnit]:
+    def get_visit_by_observation(self, site: Site, obs_idx: int ) -> Optional[Visit]:
         """
         Retrieve the unit that owns the observation 
         """

--- a/greedy_max/schedule.py
+++ b/greedy_max/schedule.py
@@ -35,7 +35,7 @@ class Observation:
     def __str__(self) -> str:
         return f'{self.idx}-{self.name}'
 
-class SchedulingUnit:
+class Visit:
     def __init__(self,
                  idx: int,
                  site: Site, 

--- a/greedy_max/utils.py
+++ b/greedy_max/utils.py
@@ -1,6 +1,6 @@
 import greedy_max
 from typing import List, Dict
-from greedy_max.schedule import Observation, SchedulingUnit
+from greedy_max.schedule import Observation, Visit
 from greedy_max.site import Site
 from astropy.units.quantity import Quantity
 from astropy.time import Time
@@ -14,10 +14,10 @@ def sites_from_column_names(colnames: List[str], column: str = 'weight') -> List
     """
     return [Site(name[name.rfind('_') + 1:]) for name in colnames if column in name]
 
-def get_observations(units: List[SchedulingUnit]) -> Dict[int,Observation]:
+def get_observations(visits: List[Visit]) -> Dict[int,Observation]:
     obs = {}
-    for unit in units:
-        aux = unit.get_observations() 
+    for visit in visits:
+        aux = visit.get_observations() 
         obs = {**obs, **aux} # merge obs and aux 
     return obs
 

--- a/solver_greedy_max.py
+++ b/solver_greedy_max.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
     tot_times = {obs_id: int(np.ceil(otab_gngs['tot_time'].quantity[idx] / dt.to(u.h).value)) for idx, obs_id in enumerate(obs_ids)}
     categories = {obs_id: Category(otab_gngs['obsclass'][idx].lower()) for idx, obs_id in enumerate(obs_ids)}
 
-    units = [] 
+    visits = [] 
     for grp_id, group in enumerate(grptab_gngs):
         obs_idxs = group['oidx']
         can_be_split = group['split']
@@ -119,7 +119,7 @@ if __name__ == '__main__':
             observations = [new_obs] if new_obs == Category.Science or Category.ProgramCalibration else []
             calibrations = [new_obs] if new_obs == Category.PartnerCalibration  else []
 
-        units.append(SchedulingUnit(grp_id, site, observations, calibrations, 
+        visits.append(Visit(grp_id, site, observations, calibrations, 
                                     can_be_split, standard_time))
 
     airmass_gs = {idx: otab_gngs['airmass_gs'][idx] for idx, obs_id in enumerate(obs_ids)}
@@ -142,9 +142,9 @@ if __name__ == '__main__':
     nt = len(uttime_gngs) # NOTE: What is this for?
 
     # Make initial plan
-    gm = GreedyMax(units, time_slots, sites)
+    gm = GreedyMax(visits, time_slots, sites)
     gm.schedule()
-    plan, obstab, targtab = gm.plan, gm.observations, gm.time_slots
+    plan, obstab, targtab = gm.plan, gm.visits, gm.time_slots
 
     # Print current plan
     # i_day = 0

--- a/solver_greedy_max.py
+++ b/solver_greedy_max.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     #print(otab_gngs.colnames)
     #print(ttab_gngs.colnames)
     
-    night_date = '2018-06-20'
+    night_date = '2019-01-03'
     sites = list(sites_from_column_names(ttab_gngs.colnames))
     dt = time_slot_length(timestab_gngs['time'])
     # Resource API mock 


### PR DESCRIPTION
This PR contains both SCHED 30 and 29.

- On the Resource Mock:
   - There was an error at reading the excel file that caused missing information
   -  Information of missing dates is retrieve from the nearest date before the asking one 
- On the Naming convention:
   - The `Scheduling Unit` class was renamed `Visit` in according with the correct definition.